### PR TITLE
Abc API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -313,6 +313,20 @@ find_package(Threads)
 list(APPEND Z3_DEPENDENT_LIBS Threads::Threads)
 
 ################################################################################
+# ABC library
+################################################################################
+find_package(Abc)
+if (ABC_FOUND)
+  include_directories(${ABC_INCLUDE_DIR})
+  # set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${ABC_CXXFLAGS}")
+  list(APPEND Z3_COMPONENT_CXX_FLAGS ${ABC_CXXFLAGS})
+  list(APPEND Z3_DEPENDENT_LIBS ${ABC_LIBRARY})
+  list(APPEND Z3_COMPONENT_CXX_DEFINES "-DABC_FOUND")
+else()
+  set(ABC_LIBRARY "")
+endif ()
+
+################################################################################
 # Compiler warnings
 ################################################################################
 include(${PROJECT_SOURCE_DIR}/cmake/compiler_warnings.cmake)
@@ -644,11 +658,3 @@ cmake_dependent_option(Z3_ENABLE_AIG_EXTERNAL_TARGETS
 if (Z3_ENABLE_AIG_EXTERNAL_TARGETS)
   add_subdirectory(externals)
 endif()
-
-find_package(Abc)
-if (ABC_FOUND)
-  include_directories(${ABC_INCLUDE_DIR})
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${ABC_CXXFLAGS}")
-else()
-  set(ABC_LIBRARY "")
-endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -644,3 +644,11 @@ cmake_dependent_option(Z3_ENABLE_AIG_EXTERNAL_TARGETS
 if (Z3_ENABLE_AIG_EXTERNAL_TARGETS)
   add_subdirectory(externals)
 endif()
+
+find_package(Abc)
+if (ABC_FOUND)
+  include_directories(${ABC_INCLUDE_DIR})
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${ABC_CXXFLAGS}")
+else()
+  set(ABC_LIBRARY "")
+endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -315,13 +315,18 @@ list(APPEND Z3_DEPENDENT_LIBS Threads::Threads)
 ################################################################################
 # ABC library
 ################################################################################
+unset(ABC_LIBRARY)
 find_package(Abc)
 if (ABC_FOUND)
   include_directories(${ABC_INCLUDE_DIR})
-  # set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${ABC_CXXFLAGS}")
   list(APPEND Z3_COMPONENT_CXX_FLAGS ${ABC_CXXFLAGS})
   list(APPEND Z3_DEPENDENT_LIBS ${ABC_LIBRARY})
   list(APPEND Z3_COMPONENT_CXX_DEFINES "-DABC_FOUND")
+
+  # -lreadline
+  list(APPEND Z3_DEPENDENT_LIBS "readline")
+  # -ldl
+  list(APPEND Z3_DEPENDENT_LIBS ${CMAKE_DL_LIBS})
 else()
   set(ABC_LIBRARY "")
 endif ()
@@ -656,5 +661,10 @@ cmake_dependent_option(Z3_ENABLE_AIG_EXTERNAL_TARGETS
     "Build Z3 with AIG externals(aiger and abc)" ON
     "CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR" OFF)
 if (Z3_ENABLE_AIG_EXTERNAL_TARGETS)
+  configure_file(
+    "${PROJECT_SOURCE_DIR}/externals/aigercmakelist.in"
+    "${PROJECT_SOURCE_DIR}/externals/aiger/CMakeLists.txt"
+    @ONLY
+  )
   add_subdirectory(externals)
 endif()

--- a/cmake/modules/FindAbc.cmake
+++ b/cmake/modules/FindAbc.cmake
@@ -4,7 +4,7 @@ if (ABC_ROOT STREQUAL "")
   message("Using default Abc library under externals/")
   set(ABC_ROOT ${PROJECT_SOURCE_DIR}/externals/abc CACHE PATH "Root of ABC compiled source tree." FORCE)
 endif()
-find_program(ABC_ARCH_FLAGS NAMES abc_arch_flags_program PATHS ${ABC_ROOT})
+find_program(ABC_ARCH_FLAGS NAMES "abc_arch_flags_program.exe" PATHS ${ABC_ROOT})
 
 if (ABC_ARCH_FLAGS)
   execute_process (COMMAND ${ABC_ARCH_FLAGS}
@@ -13,7 +13,6 @@ if (ABC_ARCH_FLAGS)
 
   message (STATUS "ABC arch flags are: ${ABC_CXXFLAGS}")
 endif()
-
 find_path(ABC_INCLUDE_DIR NAMES base/abc/abc.h PATHS ${ABC_ROOT}/src)
 find_library(ABC_LIBRARY NAMES abc PATHS ${ABC_ROOT})
 

--- a/cmake/modules/FindAbc.cmake
+++ b/cmake/modules/FindAbc.cmake
@@ -1,0 +1,23 @@
+set(ABC_ROOT "" CACHE PATH "Root of ABC compiled source tree.")
+# in our use case, by default abc is located in ${proj_root}/externals/abc
+if (ABC_ROOT STREQUAL "")
+  message("Using default Abc library under externals/")
+  set(ABC_ROOT ${PROJECT_SOURCE_DIR}/externals/abc CACHE PATH "Root of ABC compiled source tree." FORCE)
+endif()
+find_program(ABC_ARCH_FLAGS NAMES abc_arch_flags_program PATHS ${ABC_ROOT})
+
+if (ABC_ARCH_FLAGS)
+  execute_process (COMMAND ${ABC_ARCH_FLAGS}
+    OUTPUT_VARIABLE ABC_CXXFLAGS
+    OUTPUT_STRIP_TRAILING_WHITESPACE )
+
+  message (STATUS "ABC arch flags are: ${ABC_CXXFLAGS}")
+endif()
+
+find_path(ABC_INCLUDE_DIR NAMES base/abc/abc.h PATHS ${ABC_ROOT}/src)
+find_library(ABC_LIBRARY NAMES abc PATHS ${ABC_ROOT})
+
+include (FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Abc
+  REQUIRED_VARS ABC_LIBRARY ABC_INCLUDE_DIR ABC_CXXFLAGS)
+mark_as_advanced(ABC_LIBRARY ABC_INCLUDE_DIR ABC_CXXFLAGS ABC_ARCH_FLAGS)

--- a/src/smt/CMakeLists.txt
+++ b/src/smt/CMakeLists.txt
@@ -1,3 +1,6 @@
+if(ABC_FOUND)
+  set(ABC_SOURCES abc.cpp)
+endif()
 z3_add_component(smt
   SOURCES
     arith_eq_adapter.cpp
@@ -75,6 +78,7 @@ z3_add_component(smt
     user_propagator.cpp
     uses_theory.cpp
     watch_list.cpp
+    ${ABC_SOURCES}
   COMPONENT_DEPENDENCIES
     solver_assertions
     bit_blaster

--- a/src/smt/abc.cpp
+++ b/src/smt/abc.cpp
@@ -1,0 +1,15 @@
+#include "smt/abc.h"
+
+expr *smt::abc_exec(expr *e, const char *cmd) {
+  ABC_NAMESPACE::Abc_Start();
+  // XXX: convert expr* to abc aig
+  ABC_NAMESPACE::Abc_Stop();
+  return e;
+}
+
+expr *smt::abc_rewrite(expr *e) {
+  ABC_NAMESPACE::Abc_Start();
+  // XXX: convert expr* to abc aig
+  ABC_NAMESPACE::Abc_Stop();
+  return e;
+}

--- a/src/smt/abc.h
+++ b/src/smt/abc.h
@@ -1,0 +1,82 @@
+/*++
+
+Module Name:
+
+    abc.h
+
+Abstract:
+
+    Interface to ABC synthesis engine
+
+Author:
+
+    Xiang Zhou (danblitzhou) 2021-11-28
+
+Revision History:
+
+--*/
+#pragma once
+
+#include "ast/ast.h"      // expr
+#include "util/warning.h" // warning
+
+#ifdef ABC_FOUND
+#define ABC_NAMESPACE abc
+namespace ABC_NAMESPACE {
+
+// procedures to start and stop the ABC framework
+// (should be called before and after the ABC procedures are called)
+void Abc_Start();
+void Abc_Stop();
+
+// procedures to get the ABC framework and execute commands in it
+// typedef struct Abc_Ntk_t_ Abc_Ntk_t;
+// typedef struct Abc_Obj_t_ Abc_Obj_t;
+typedef struct Abc_Frame_t_ Abc_Frame_t;
+typedef struct Abc_Aig_t_ Abc_Aig_t;
+
+Abc_Frame_t *Abc_FrameGetGlobalFrame();
+int Cmd_CommandExecute(Abc_Frame_t *pAbc, const char *sCommand);
+
+// extern Abc_Ntk_t* Abc_FrameReadNtk (Abc_Frame_t *p);
+// extern void Abc_FrameDeleteAllNetworks (Abc_Frame_t *f);
+// extern void Abc_FrameSetCurrentNetwork (Abc_Frame_t *f, Abc_Ntk_t *n);
+
+// extern void Abc_ObjAddFanin( Abc_Obj_t * pObj, Abc_Obj_t * pFanin );
+
+// void NtkSetName (Abc_Ntk_t* ntk, const char *name);
+// int NtkPoNum (Abc_Ntk_t *ntk);
+// int NtkPiNum (Abc_Ntk_t *ntk);
+// Abc_Obj_t* NtkPi (Abc_Ntk_t*, int i);
+// Abc_Obj_t* NtkPo (Abc_Ntk_t*, int i);
+// Abc_Ntk_t *newAigNtk ();
+// Abc_Obj_t *NtkCreatePi (Abc_Ntk_t* ntk);
+// Abc_Obj_t *NtkCreatePo (Abc_Ntk_t* ntk);
+
+} // namespace ABC_NAMESPACE
+using namespace ABC_NAMESPACE;
+
+namespace smt {
+/** convert e to aig and execute ABC command cmd against it **/
+expr *abc_exec(expr *e, const char *cmd);
+/** convert e to aig and execute ABC command "rewrite" against it,
+ * which performs DAG-aware rewrite using NPN technique **/
+expr *abc_rewrite(expr *e);
+
+} // namespace smt
+
+#else
+// NO Abc found
+namespace smt {
+inline expr *abc_exec(expr *e, const char *cmd) {
+  warning_msg("ABC not found, command %s has no effect.", cmd);
+  return e;
+}
+
+inline expr *abc_rewrite(expr *e) {
+  warning_msg("ABC not found, DAG-aware rewrite has no effect.");
+  return e;
+}
+} // namespace smt
+
+#endif // ifdef ABC_FOUND


### PR DESCRIPTION
Created skeleton interface to Abc, cmake build system now works with Abc shared libary
First, build Abc shared library `make ABC_USE_NAMESPACE=abc CC="g++" CXX="g++" ABC_USE_PIC=1 libabc.so`;
then configure cmake and build in project root. 

Ideally want to figure out a way to automate all in cmake, but low priority as of now.